### PR TITLE
Add sprint 1 links to docs site

### DIFF
--- a/docs-site/docs/deliverables.md
+++ b/docs-site/docs/deliverables.md
@@ -8,7 +8,11 @@ hide:
 [View our initial presentation here!](https://docs.google.com/presentation/d/1trLFlhvwvZrCBgK136jpQbMUlBxeZeUl/edit?usp=sharing&ouid=108060503150477856369&rtpof=true&sd=true) <br>
 [Check out our GitHub here!](https://github.com/pierced07/Code-the-Clinic)
 ## Sprint 1
-We're working on it! Please check back after 2/17/26.
+[Project planning document](https://bama365-my.sharepoint.com/:w:/g/personal/hrhendersonboyer_crimson_ua_edu/IQCDd_xa88unS41cWVgj8xNpATZRSViApXzf05_EgLX_KH8?e=9pllBP) <br>
+[Project backlog](https://bama365-my.sharepoint.com/:w:/g/personal/hrhendersonboyer_crimson_ua_edu/IQBIMI5Ql7TETbmIl2YFVq7LAY0MzXoGmTjE1ZZq6nE8B54?e=4W2zU0) <br>
+[Sprint backlog](https://bama365-my.sharepoint.com/:w:/g/personal/hrhendersonboyer_crimson_ua_edu/IQDXqx37RzhhRKLIJktzLrsQAXDVzmmugxe2lNLQALq15mY?e=Huj3T6) <br>
+[Sprint retrospective](https://bama365-my.sharepoint.com/:w:/g/personal/hrhendersonboyer_crimson_ua_edu/IQA-IFTeUA4IQJAiCB8o33PgAQGFPaxaBNVsstYoOb2GSBo?e=N1NugA) <br>
+[Sprint presentation](https://bama365-my.sharepoint.com/:p:/g/personal/hrhendersonboyer_crimson_ua_edu/IQDUKlkdzOU-TaS_toubxJXSAYs9s1Ke9nbwkeiFe49UUow?e=wiDlh9)
 ## Sprint 2
 We're working on it! Please check back after 3/24/26.
 ## Sprint 3


### PR DESCRIPTION
Changes:
- Update documentation with sprint 1 links (in-progress presentation, planning document, project backlog, sprint backlog, retrospective)