### PR TITLE
[Security] Remove last instance of @csrf_exempt, resolves #29

### DIFF
--- a/backend/clinic_reports/views.py
+++ b/backend/clinic_reports/views.py
@@ -1,7 +1,6 @@
 from django.shortcuts import render
 from django.http import JsonResponse
 from django.views.decorators.http import require_http_methods
-from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth.decorators import login_required
 from django.core.validators import validate_email
 from django.core.exceptions import ValidationError
@@ -21,7 +20,6 @@ def form_view(request):
     return render(request, 'clinic_reports/form.html', context)
 
 
-@csrf_exempt # TODO: Remove this and use CSRF tokens to tighten security before launching in production!
 @require_http_methods(["POST"])
 def submit_report(request):
     """API endpoint to submit clinic report.

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1,7 +1,6 @@
 from django.shortcuts import render, redirect
 from django.http import JsonResponse
 from django.views.decorators.http import require_http_methods
-from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth.decorators import login_required
 from django.db.models import Avg, Sum, F, Case, When, IntegerField, Value, FloatField
 from django.db.models.functions import Coalesce


### PR DESCRIPTION
Changes:
- Remove all @csrf_exempt imports and decorators to use the csrf token functionality that was implemented in form.html.