### PR TITLE
Remove port from logged IP addresses so that Postgres inet field will accept it

### DIFF
--- a/backend/user_logging/middleware.py
+++ b/backend/user_logging/middleware.py
@@ -20,8 +20,19 @@ SENSITIVE_QUERY_KEYS = {
 def _get_ip_address(request):
     forwarded = request.META.get('HTTP_X_FORWARDED_FOR')
     if forwarded:
-        return forwarded.split(',')[0].strip()
-    return request.META.get('REMOTE_ADDR')
+        candidate = forwarded.split(',')[0].strip()
+    else:
+        candidate = request.META.get('REMOTE_ADDR')
+
+    if not candidate:
+        return candidate
+
+    # Some hosting environments include the port (e.g. "1.2.3.4:56789").
+    # Strip the port for IPv4-style addresses so it fits GenericIPAddressField.
+    if ':' in candidate and candidate.count('.') == 3:
+        candidate = candidate.split(':', 1)[0]
+
+    return candidate
 
 
 def _sanitize_query_string(raw_query):

--- a/backend/user_logging/signals.py
+++ b/backend/user_logging/signals.py
@@ -45,8 +45,19 @@ def _get_ip_address(request):
 
     forwarded = request.META.get('HTTP_X_FORWARDED_FOR')
     if forwarded:
-        return forwarded.split(',')[0].strip()
-    return request.META.get('REMOTE_ADDR')
+        candidate = forwarded.split(',')[0].strip()
+    else:
+        candidate = request.META.get('REMOTE_ADDR')
+
+    if not candidate:
+        return candidate
+
+    # Some hosting environments include the port (e.g. "1.2.3.4:56789").
+    # Strip the port for IPv4-style addresses so it fits GenericIPAddressField.
+    if ':' in candidate and candidate.count('.') == 3:
+        candidate = candidate.split(':', 1)[0]
+
+    return candidate
 
 
 def _build_base_log_data(request):


### PR DESCRIPTION
Postgres has a special INET type for IP addresses that allows for IP address specific filtering of records. However, this type doesn't allow <IP address:port> format, so I tweaked the _get_ip_address() methods in the logging middleware to strip the port from IP addresses before attempting to add to the database. This should fix the DataError upon login/logout when trying to log these events.