### PR TITLE
Remove unnecessary help messages

### DIFF
--- a/backend/clinic_reports/templates/clinic_reports/form.html
+++ b/backend/clinic_reports/templates/clinic_reports/form.html
@@ -190,9 +190,6 @@
       ✗ Error submitting report. Please try again.
     </div>
     <ul id="field-errors" class="error-message" style="display:none; list-style:disc; margin-left:2em;" role="alert" aria-live="assertive" tabindex="-1"></ul>
-    <div class="muted" style="margin-top:24px; text-align:center; font-size:14px;">
-      Need help? Contact your program director or email <a href="mailto:clinic-support@example.edu">clinic-support@example.edu</a>.
-    </div>
   <script>
     // Helper to read cookie (to send CSRF token in XHR headers)
     function getCookie(name) {

--- a/backend/core/templates/core/home.html
+++ b/backend/core/templates/core/home.html
@@ -45,9 +45,3 @@
     </div>
 {% endif %}
 {% endblock %}
-
-{% block helpinfo %}
-<footer style="margin-top:40px; text-align:center; color:#555; font-size:14px;">
-    Need help? Contact your program director or email <a href="mailto:clinic-support@example.edu">clinic-support@example.edu</a>.
-</footer>
-{% endblock %}


### PR DESCRIPTION
Changes:
- Remove example help messages from homepage and clinic report form (the email they provided was not real)