### PR TITLE
Add cloud deployment scripts, documentation, and cyber assessment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ db.sqlite3
 backend/config/__pycache__/settings.cpython-311.pyc
 backend/config/__pycache__/urls.cpython-311.pyc
 my_notes.md
+main-local.bicepparam
+user-notes.md

--- a/cloudshell_db_bootstrap.sh
+++ b/cloudshell_db_bootstrap.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# Cloud Shell DB bootstrap for Code the Clinic
+#
+# Use this script from Azure Cloud Shell AFTER:
+#   - main.bicep has been deployed with runAutomatedDbIdentitySetup = false
+#   - You (or whoever runs this) is temporarily an Entra admin on the
+#     PostgreSQL flexible server.
+#
+# This script will:
+#   1. Fetch an Entra token for PostgreSQL (used as password)
+#   2. Ensure the pgaadauth extension exists
+#   3. Create a role matching the App Service name (if needed)
+#   4. Apply the pgaadauth security label linking that role to the
+#      App Service managed identity
+#   5. Grant DB/schema/table/sequence permissions to that role
+#
+# After running, the App Service managed identity should be able to
+# connect to the DB using Entra authentication.
+# -----------------------------------------------------------------------------
+
+# 1. Variables - update these to match your environment
+#    You can copy most values from your bicep parameters.
+
+# FQDN of the Postgres flexible server
+DB_HOST="<db_name>.postgres.database.azure.com"
+# Name of the application database (usually same as server name)
+DB_NAME="<db_name>"             
+# Name of the App Service (must match what Django uses as POSTGRES_USER)
+APP_SERVICE_NAME="<app_service_name>"        
+# Resource group containing the App Service
+RESOURCE_GROUP="your-resource-group-here"
+# Optional: if you already know the managed identity object ID for the App Service,
+# you can set it here to avoid calling az webapp identity show (which may require extra permissions).
+# Example: APP_OBJECT_ID="00000000-0000-0000-0000-000000000000"
+APP_OBJECT_ID=""
+
+# 2. Get your Entra principal and access token (you must be Postgres Entra admin)
+echo "Fetching signed-in Entra user principal..."
+DB_USER=$(az ad signed-in-user show --query "userPrincipalName" -o tsv)
+
+if [ -z "${DB_USER:-}" ]; then
+  echo "❌ Could not resolve signed-in Entra user (DB_USER). Are you logged in with az login?"
+  exit 1
+fi
+
+echo "Fetching Entra access token for PostgreSQL..."
+export PGPASSWORD=$(az account get-access-token --resource-type oss-rdbms --query "[accessToken]" -o tsv)
+
+if [ -z "${PGPASSWORD:-}" ]; then
+  echo "❌ Could not obtain access token for PostgreSQL."
+  exit 1
+fi
+
+# 3. Fetch or use the App Service managed identity object ID
+if [ -n "${APP_OBJECT_ID:-}" ]; then
+  echo "Using provided App Service object ID: ${APP_OBJECT_ID}"
+else
+  echo "Fetching managed identity principalId for App Service '${APP_SERVICE_NAME}' in resource group '${RESOURCE_GROUP}'..."
+  APP_OBJECT_ID=$(az webapp identity show \
+    --name "${APP_SERVICE_NAME}" \
+    --resource-group "${RESOURCE_GROUP}" \
+    --query principalId -o tsv)
+
+  if [ -z "${APP_OBJECT_ID:-}" ]; then
+    echo "❌ Error: Could not find App Service managed identity. Is system-assigned identity enabled on the App Service?"
+    exit 1
+  fi
+
+  echo "Found App Service object ID: ${APP_OBJECT_ID}"
+fi
+
+# 4. Create role, apply security label, and grant permissions
+#    We connect to the 'postgres' database for metadata (extension + label),
+#    then to the application database for schema/table grants.
+
+APP_ROLE="${APP_SERVICE_NAME}"
+
+cat <<'SQL' | psql "host=${DB_HOST} port=5432 dbname=postgres user=${DB_USER} sslmode=require" \
+  -v ON_ERROR_STOP=1 \
+  -v app_role="${APP_ROLE}" \
+  -v app_oid="${APP_OBJECT_ID}" \
+  -v db_name="${DB_NAME}"
+-- Create role for the App Service if it doesn't already exist
+SELECT format('CREATE ROLE %I WITH LOGIN', :'app_role')
+WHERE NOT EXISTS (
+  SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = :'app_role'
+) \gexec
+
+-- Apply security label tying the role to the App Service managed identity
+SELECT format(
+  'SECURITY LABEL FOR pgaadauth ON ROLE %I IS %L',
+  :'app_role',
+  format('aadauth,oid=%s,type=service', :'app_oid')
+) \gexec
+
+-- Grant CONNECT on the application database
+SELECT format('GRANT CONNECT ON DATABASE %I TO %I', :'db_name', :'app_role') \gexec
+SQL
+
+# Now grant schema/table/sequence privileges inside the application database
+cat <<'SQL' | psql "host=${DB_HOST} port=5432 dbname=${DB_NAME} user=${DB_USER} sslmode=require" \
+  -v ON_ERROR_STOP=1 \
+  -v app_role="${APP_ROLE}"
+-- Basic schema and object permissions for the app role
+SELECT format('GRANT USAGE ON SCHEMA public TO %I', :'app_role') \gexec
+SELECT format('GRANT CREATE ON SCHEMA public TO %I', :'app_role') \gexec
+SELECT format('GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO %I', :'app_role') \gexec
+SELECT format('GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO %I', :'app_role') \gexec
+SELECT format('ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO %I', :'app_role') \gexec
+SELECT format('ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO %I', :'app_role') \gexec
+SQL
+
+echo "✅ DB identity bootstrap complete."
+echo "The App Service managed identity '${APP_SERVICE_NAME}' should now be able to connect to '${DB_NAME}' on '${DB_HOST}' using Entra authentication."

--- a/docs-site/docs/cyber-assessment.md
+++ b/docs-site/docs/cyber-assessment.md
@@ -1,0 +1,37 @@
+---
+hide:
+  - navigation
+---
+
+# Cyber assessment
+
+## Overall assessment
+We have implemented a variety of security features to prevent common attacks, including DDoS, cross-site request forgery, privilege escalation, and malicious code execution. Our application is deployed in a secure University-owned Azure tenant, and permissions on the resource group where we have deployed the application are limited to those who are currently working on the project. Overall, our application is secure and ready for production use.
+
+## Security features we implemented
+- Secure myBama authentication using an official UA Microsoft app registration
+- Force social account login in production (SOCIALACCOUNT_ONLY = True automatically in Azure) so that no one can use the standard Django username/password login--this lowers the risk of brute-force attacks
+- Set an environment variable (ALLOW_PASSWORD_ADMIN_LOGIN) to prevent users from being able to log into the Django admin portal using a username and password (they MUST log in with myBama) unless this is set to True (in production, this should only be done temporarily to create an emergency superuser in case of accidental account lockouts. During normal use, all users, including admins, should be exclusively using myBama credentials to sign in.)
+- Enabled Axes, a Django add-on that logs all access attempts in the admin portal and locks out users after a set number of incorrect login attempts (this is to add an extra layer of protection against brute-force attacks if username/password login is temporarily enabled for the admin portal)
+- Use secure cookies by default
+- Enforce HTTPS-only traffic (if anyone tries to access our website via standard HTTP, they will be automatically redirected to HTTPS)
+- Use an activity logging system (logs are visible in the Django admin portal) to record IP addresses and usernames of everyone who has logged in/out of the system
+  - [Next steps] Coordinate with IT to send these logs to UA's Splunk system so IT can easily view access records
+- Fixed vulnerabilities identified by cyber team:
+  - Enabled rate limiting in django settings (CWE-770)
+  - Sanitized URLs in href tags to prevent execution of malicious javascript (CWE-79)
+  - Added integrity attribute for external CDN files to ensure they haven't been tampered with (CWE-353)
+    - [Next steps] Possibly add Django "url" tags instead of manually sanitizing   urls for an extra layer of reliability
+  - [Local dev] Prevented privilege escalation in local DB resource with 'no-new-privileges: true' (CWE-732)
+  - [Local dev] Made the local DB's filesystem read-only (read_only: true) to prevent execution of malicious code (CWE-732)
+  - Use CSRF tokens to prevent cross-site request forgery
+  - Use Python logging instead of print statements for detailed error messages to prevent stack trace exposure
+
+## Issues to review periodically
+- Encourage sponsor (AT department) to use the principle of least privilege with admin permissions--admins can click on any user and set their permissions in a more granular way--not every admin has to be a superuser (able to see all the data in the admin portal, create new users, etc.)
+- Make sure that DEBUG is set to False in the Azure App Service's environment variables--this prevents detailed error messages from being exposed to attackers.
+- Make sure that ALLOW_PASSWORD_ADMIN_LOGIN is set to false
+- Unless you are actively creating/editing secrets, make sure that the Key Vault is set to only accept traffic from the VNet that contains the App Service and DB (not any other IP addresses). You can check this under the Key Vault's Networking settings.
+- Make sure the database (Azure DB for PostgreSQL resource in the Azure portal) is set to only accept traffic from the private endpoint that connects to the App Service's VNet. You can check this in the DB's Networking settings.
+- Perform periodic audits for any instances of @csrf_exempt--you shouldn't have any instances of this in production code because all API endpoints should be protected by CSRF tokens.
+

--- a/docs-site/docs/deployment-docs.md
+++ b/docs-site/docs/deployment-docs.md
@@ -4,6 +4,8 @@ hide:
 ---
 
 # How to deploy the application
+*Created by Holland Henderson-Boyer*
+
 Hi! Here's how to run our application locally, run tests, and deploy it in the cloud. In case you need to change Azure accounts later (for example, to move the application fully into the university tenant), you can use the Azure CLI and the bicep template files we've included to deploy without spending hours clicking through Azure's terrible GUI :)
 
 ## Required setup tools
@@ -63,10 +65,17 @@ Hi! Here's how to run our application locally, run tests, and deploy it in the c
         - Delete the manually created superuser when you are done for security
         - Now when you log in with your crimson email you should automatically be able to see the admin dashboard!
 
-## How to deploy to the cloud
+## How to deploy to Azure
+We currently have the application deployed in the university's Azure tenant! The name of our resource group is CHES-CS495-Capstone-Team-Code-the-Clinic-RG. There is a cost associated with our deployed resources (currently about $37 per month), which is billed to the AT department.
+If you need to re-deploy in the university's tenant for any reason (changing regions, fatal problem with current deployment, etc.), ask for the following roles from IT for bootstrapping:
+- Contributor
+- Key Vault Secrets Officer (to add new secrets)
+- Managed Identity Operator
+- Role Based Access Control Administrator
+After initial setup, you should only need Contributor (and possibly Key Vault Secrets Officer if you need to add/update secrets in Key Vault).
 
 ### Pre-deployment todos
-- Fill in environment variables in main.bicepparam (before doing this, make your own local copy of main.bicepparam (main-local.bicepparam) that is gitignored so so environment variables aren't in a public github)
+- Fill in environment variables in main.bicepparam (before doing this, make your own local copy of main.bicepparam (call it main-local.bicepparam) that is gitignored so so environment variables aren't in a public github)
 
 ### Deploying the application
 - Run `az login` to log into the Azure CLI and then select the subscription you want to copy the application into.
@@ -145,8 +154,8 @@ az stack group delete --name clinic-test-stack --resource-group <rg-name> --acti
         az postgres flexible-server execute --name <postgres-server-name> --admin-user $USERNAME --admin-password $TOKEN --database-name=<db-name-should-be-same-as-postgres-server-name> --querytext "UPDATE auth_user SET is_staff = true, is_superuser = true WHERE email = '<your-crimson-email>';" 
         ```
     - Remove your Entra admin status in the PostgreSQL server settings
-- [IMPORTANT] Remove Contributor role assignment from the deployment-script managed identity (this identity was created solely to set up initial DB permissions and is no longer needed.)
-- [IMPORTANT] Revoke Entra admin status from the "test-dbscript" managed identity
+- [IMPORTANT] (You don't need to do this if you set runAutomatedDbIdentitySetup=false) Remove Contributor role assignment from the deployment-script managed identity (this identity was created solely to set up initial DB permissions and is no longer needed.)
+- [IMPORTANT] (You don't need to do this if you set runAutomatedDbIdentitySetup=false) Revoke Entra admin status from the "test-dbscript" managed identity
     - Run these commands in the Azure Cloud Shell or local terminal, one at a time:
         ```bash
         USERNAME=$(az ad signed-in-user show --query "userPrincipalName" -o tsv)

--- a/docs-site/docs/deployment-docs.md
+++ b/docs-site/docs/deployment-docs.md
@@ -1,0 +1,196 @@
+---
+hide:
+  - navigation
+---
+
+# How to deploy the application
+Hi! Here's how to run our application locally, run tests, and deploy it in the cloud. In case you need to change Azure accounts later (for example, to move the application fully into the university tenant), you can use the Azure CLI and the bicep template files we've included to deploy without spending hours clicking through Azure's terrible GUI :)
+
+## Required setup tools
+- Docker Desktop (needed to run Docker locally)
+- VS Code or preferred IDE
+
+## How to run in development
+- Set up environment variables
+    - Open .env-example and set the environment variables according to the guidelines (but do this in a different file, .env, and put .env in gitignore so that you don't expose any secrets.)
+    - For Azure credentials, see the "How to get myBama auth working..." section--local Azure credentials are only needed if you want to test myBama auth locally
+- If you are setting up your dev environment and running the app locally for the first time, run this command once to apply all existing database migrations: `docker-compose exec backend python manage.py migrate`
+- To run the documentation website and the django backend: `docker-compose up`
+- To run the documentation website and the django backend and rebuild the docker container (for example, if you added new dependencies to requirements.txt): `docker-compose up --build`
+- To update the local database:
+    - Create migration: `docker-compose exec backend python manage.py makemigrations clinic_reports`
+        - Use the name of the data model instead of clinic_reports if updating a different model
+    - Run migration: `docker-compose exec backend python manage.py migrate`
+- To create a superuser (required to locally test the admin page without a Microsoft account): `docker-compose exec backend python manage.py createsuperuser`
+
+## How to test
+- To run all tests: `docker-compose exec backend python manage.py test`
+- To run all tests for a specific app (currently our only two apps are clinic_reports and core): `docker-compose exec backend python manage.py test app-name`
+    - For example, `python manage.py test clinic_reports` would run all the tests under the clinic_reports app (these check whether the form authentication and submission logic works correctly).
+
+## How to debug locally
+- If you are getting Django import errors after force-quitting and restarting Docker Desktop, try these steps to force re-creating all Docker containers without cache (in case the cache got corrupted during the abrupt restart). WARNING: This will delete all the records in your local database! NEVER use this method in production--only in local development!
+`docker-compose down -v` (removes all containers and deletes all associated volumes)
+`docker system prune -f` (removes all unused data)
+`docker-compose up --build` (rebuilds all the containers without caching)
+- If you are getting DB errors that the relation "django-session" doesn't exist, you need to run the migration command listed in the "how to run" section to recreate all the tables that Django expects to be in the database.
+
+## How to get myBama auth working in your local environment
+- Get a personal Azure tenant ID and secret by creating an Azure account
+    1. Create the app registration
+        - In your personal Azure Portal (portal.azure.com), search for "App registrations" and click "New registration".
+        - If you don’t have an Azure account and see something like “tenant blocked due to inactivity,” make a new Azure account, wait 5 minutes, and try again. 
+        - Name: Doesn't matter, make this whatever you want 
+        - Supported account types: Select the option that says: "Accounts in any organizational directory (Any Microsoft Entra ID tenant - Multitenant)". Do NOT select "Personal Microsoft accounts only". 
+        - Redirect URI: (For local development) Select Web and enter http://localhost:8000/accounts/microsoft/login/callback/. This allows us to test myBama auth locally.
+        - Click Register. 
+
+    2. Get your keys
+        - Once created, you will land on the Overview page.
+        - Copy the Application (client) ID. -> Paste this into your .env as AZURE_CLIENT_ID. 
+        - Go to Certificates & secrets (sidebar) -> New client secret.
+        - Description: dev-secret, Expires: 6 months 
+        - Click Add -> Copy the Value (not the ID!). -> Paste this into your .env as AZURE_SECRET 
+        - Put your Azure tenant ID and secret in .env (follow the instructions in .env-example)
+        - Go to /accounts/microsoft/login and it should let you authenticate with myBama
+
+    3. If you want to be automatically logged in to the admin portal with myBama, you will need to follow these steps:
+        - Log in with myBama--this will create a user in the system for you
+        - Log out
+        - Create a superuser: docker-compose exec backend python manage.py createsuperuser
+        - Log in to the admin portal as the superuser
+        - Use the admin portal to give your myBama user superuser permissions
+        - Delete the manually created superuser when you are done for security
+        - Now when you log in with your crimson email you should automatically be able to see the admin dashboard!
+
+## How to deploy to the cloud
+
+### Pre-deployment todos
+- Fill in environment variables in main.bicepparam (before doing this, make your own local copy of main.bicepparam (main-local.bicepparam) that is gitignored so so environment variables aren't in a public github)
+
+### Deploying the application
+- Run `az login` to log into the Azure CLI and then select the subscription you want to copy the application into.
+- Run this command in your terminal to validate the bicep file and its associated params file for any errors:
+```bash
+az deployment group validate -g <new-resource-group> -f main.bicep -p main-local.bicepparam --query "properties.validationResultItems[?severity=='Error']"
+```
+- Run this command to preview the resources that will be created:
+```bash
+az deployment group what-if --resource-group <new-resource-group> -f main.bicep -p main-local.bicepparam
+```
+- Run either of these commands to deploy the bicep file to a new Azure resource group: 
+```bash
+az deployment group create \
+    -g <new-azure-resource-group> \
+    -f main.bicep \
+    -p main.bicepparam
+```
+```bash
+az stack group create --name clinic-test-stack --resource-group <new-resource-group> --template-file main.bicep --parameters main-local.bicepparam --deny-settings-mode none --action-on-unmanage deleteAll
+```
+
+- NOTE: If the deployment fails midway through and you want a fresh start, if you used the second command (az stack group create ...) you can use this command to delete all the resources created via the deployment command. ONLY use this if you want to delete all the resources you just tried to deploy.
+- NOTE: If the deployment script resource fails with a permission error (this may happen if you are in UA's tenant), you can set runAutomatedDbIdentitySetup = false in main-local.bicepparam to prevent the deployment script from running. You will need to do one additional manual task during post-deployment to enable the DB and App Service to communicate.
+
+```bash
+az stack group delete --name clinic-test-stack --resource-group <rg-name> --action-on-unmanage deleteAll
+```
+
+### Post-deployment todos
+- If you set runAutomatedDbIdentitySetup = false, enter the required variables in cloudshell_db_bootstrap.sh (located at the root of the GitHub repo) and copy the script into a new Cloud Shell session. This script will perform the same action as the deployment script in the Bicep file--setting up the DB to recognize the App Service's managed identity, and giving the App Service permission to modify tables in the DB.
+- Add yourself as a Key Vault Secrets Officer
+    - Go to your Key Vault => Access control (IAM) => Role assignments => New role assignment => Assign yourself the Key Vault Secrets Officer role. This will let you view, add, and edit secrets, which you will need to do to set up the application.
+- If you can't access the "Secrets" tab in your Key Vault because of a firewall rule:
+    - Go into the networking tab and temporarily add your client IP address under firewall rules. If this doesn't work (for example, if you are on campus and using a UA IP that constantly changes), you can temporarily select "allow public access from all networks"--just make sure to change this back to the original secure setting (allow public access from specific virtual networks...") once you're done!
+- Add all secrets to Key Vault
+    - azure-client-id (Client ID from Azure app registration, NOT app service)
+    - microsoft-login-client-id (same as azure-client-id)
+    - azure-secret (Add a new client secret under your Azure app registration and add the secret to Key Vault)
+    - azure-tenant-id (Tenant ID from Azure app registration, NOT app service)
+        - If you aren't using a single-tenant setup for myBama authentication (i.e. the university's tenant), you can just set this to "common". Otherwise use the tenant ID from the Azure app registration.
+    - django-secret-key
+        - Generate a new one with this command: `python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())`
+    - postgres-db (This isn't really a secret--it can be moved outside of key vault if needed. Name of the database within your PostgreSQL server in Azure where your Django tables are. You can find your databases in your PostgreSQL server settings => Databases.)
+    - db-host (the domain of your Postgre DB--can be found in the Overview section if you click on your Postgres DB in the Azure portal)
+    - postgres-user (the name of the App Service, since the App Service uses a Managed Identity to communicate with the DB)
+- Update environment variables (if needed) to match this state:
+    - For variables that are in Key Vault, use a string like this: `@Microsoft.KeyVault(SecretUri=<https://<vault-name>.vault.azure.net/secrets/<secret-name>/)`
+    - MICROSOFT_LOGIN_CLIENT_ID = In key vault (azure-client-id)
+    - AZURE_SECRET = In key vault (azure-secret)
+    - AZURE_TENANT_ID = In key vault (azure-tenant-id)
+    - DJANGO_SECRET_KEY = In key vault (django-secret-key)
+    - POSTGRES_DB = In key vault (postgres-db)
+    - POSTGRES_HOST = In key vault (db-host)
+    - POSTGRES_USER = In key vault (postgres-user)
+    - ALLOWED_HOSTS = 'localhost,127.0.0.1,0.0.0.0,<domain-of-app-service-application>,https://<domain-of-app-service-application>'
+    - CSRF_TRUSTED_ORIGINS = 'https://<domain-of-app-service-application>
+    - ALLOW_PASSWORD_ADMIN_LOGIN = False (if you need to allow admin login with username/password in an emergency, you can set this to True later.)
+    - Other environment variables should be OK to leave as the default values set in the template.
+- Give the App Service permission to pull the latest Docker image from GHCR
+    - Get GitHub Personal Access Token (PAT) with read:packages permission on the Code the Clinic repository
+    - Go to your new App Service => Deployment Center => click on "main" => paste the PAT into the password field and click "ok"
+- NOTE: If the app isn't working at this point (after you restart it in the App Service overview page), temporarily swich DEBUG to True in the environment variables to see the stack trace and follow the "smoke testing" instructions to look at the platform (server-level) and runtime (Django app level) logs. It's usually one of these problems:
+    - You see an error in the Runtime logs when Django tries to auto-run migrations, indicating that the app can't connect to the database. If it says something like "password authentication invalid," that means the app service isn't properly set up to log into the DB with an Entra token. Try running the cloudshell_db_bootstrap.sh script in a new Cloud Shell session to set up the DB to recognize the App Service's managed identity and give it the proper permissions to create and edit tables.
+    - You didn't add the App Service's domain to ALLOWED_HOSTS (this usually results in a 400 error). Try adding the exact domain listed in the error message to the ALLOWED_HOSTS environment variable and restart the app.
+    - There was an issue with one of your Key Vault secrets and you fixed it, but the app isn't "seeing" it because it is just pulling a cached version of what's in Key Vault (this usually results in a 500 error). Try temporarily changing an environment variable and then changing it back--this should solve the problem.
+    - You try to login with myBama and see a Microsoft login error page that says something about a redirect URL. Make sure that your App Service's domain (exactly as specified in the error message) is listed as a Redirect URL under the App Registration you are using for myBama auth.
+    - You try to login with myBama and get a "cannot assign requested address" or similar OS error. If this happens, just refresh and try logging in again--this is a transient error that only happens once, and only happens for completely new users. After refreshing and re-authenticating, the app should work as expected.
+- Promote yourself to a superuser in Django (you will need to do this the first time you deploy the app so you can access the admin pages on the site)
+    - Temporarily add yourself as an Entra admin on the DB
+        - If you didn't specify Entra administrators in the Bicep params: Go to the PostgreSQL server, Security => Authentication, and add yourself as an Entra administrator
+    - Run these commands in the Azure Cloud Shell or local terminal, one at a time:
+        ```bash
+        USERNAME=$(az ad signed-in-user show --query "userPrincipalName" -o tsv)
+        TOKEN=$(az account get-access-token --resource-type oss-rdbms --query "[accessToken]" -o tsv)
+        az postgres flexible-server execute --name <postgres-server-name> --admin-user $USERNAME --admin-password $TOKEN --database-name=<db-name-should-be-same-as-postgres-server-name> --querytext "UPDATE auth_user SET is_staff = true, is_superuser = true WHERE email = '<your-crimson-email>';" 
+        ```
+    - Remove your Entra admin status in the PostgreSQL server settings
+- [IMPORTANT] Remove Contributor role assignment from the deployment-script managed identity (this identity was created solely to set up initial DB permissions and is no longer needed.)
+- [IMPORTANT] Revoke Entra admin status from the "test-dbscript" managed identity
+    - Run these commands in the Azure Cloud Shell or local terminal, one at a time:
+        ```bash
+        USERNAME=$(az ad signed-in-user show --query "userPrincipalName" -o tsv)
+        TOKEN=$(az account get-access-token --resource-type oss-rdbms --query "[accessToken]" -o tsv)
+        ```
+    - Run this command twice, once with db-name="postgres" and once with db-name="postgresql-server-name":
+        ```bash
+        az postgres flexible-server execute --name <postgres-server-name> --admin-user $USERNAME --admin-password $TOKEN --database-name=<db-name> --querytext "REASSIGN OWNED BY \"code-the-clinic-test-dbscript-mi\" TO \"<your-admin-role>\"; DROP OWNED BY "code-the-clinic-test-dbscript-mi";
+        ```
+    - Then delete the managed identity from the Entra admin list under your PostgreSQL server => Authentication
+    - (Recommended) Remove yourself as an Entra admin (you can always add yourself back later if there's an emergency where you need to directly access the DB)
+- [IMPORTANT] Remove public access to the database
+    - Go to the database => Networking and disable public access (the DB and the App Service will still be able to communicate via their shared VNET). If you ever need to connect to the database and run SQL, you can temporarily re-enable public access, but only allow your client IP--not access from all networks. Also, make sure to disable public access again as soon as you are done.
+    - Recommended: Also delete the AllowAzureServices firewall rule, since after initial setup only the app service should be able to access the DB.
+- [IMPORTANT] Make sure Key Vault access is restricted to only the virtual network containing the app service (you can check this in the key vault's Networking settings)
+    - If there are any rules listed under Firewall, you can safely delete them--you only need the "code-the-clinic-vnet-test" or similar under Virtual Network Rules.
+- Once you are a Django admin, open the Excel file [Dropdown Options.xlsx](https://bama365-my.sharepoint.com/:x:/g/personal/hrhendersonboyer_crimson_ua_edu/IQByqE9LpDuiSqtylUDZcGq5AWHkIQcn_vfJskrzJZno9HU?e=qZJt1R) from the AT department, and then go to the Django admin portal. Add the list under "Clinical Sites" as new Sport records under the Sports section of the admin portal, and add the list under "Other Health Professions" as new Healthcare Provider records under the Healthcare Providers section of the admin portal.
+
+### Smoke testing
+- If you are experiencing HTTP errors and need to get clear error messages, you can temporarily set DEBUG=True in the App Service's environment variables. However, this makes the application more vulnerable since an attacker could see exactly what was preventing them from accessing a certain page. For this reason, you should immediately change DEBUG back to False after testing, and ideally never set DEBUG=True in the Azure portal at all (just do your testing locally instead).
+- If the app service isn't starting, you can see detailed logs in "log stream" under the App Service settings => Monitoring. (You may need to enable filesystem-level logging first if you are deploying the app for the first time in a new environment). You should be able to see "platform logs" (logs from the underlying server that is running the app) and "runtime logs" (logs from the app itself). If you don't see any runtime logs, check the platform logs to see what might be going wrong. Platform logs are where you would see problems pulling the Docker container from GitHub Container Registry or problems pinging the app for health checks. Runtime logs are where you would see Django errors (failed to run migrations, normal website errors like 403/400/etc.)
+
+### Troubleshooting and known issues
+- If the app seems to start (check runtime Log Stream in the app service for gunicorn logs) but you are getting "gateway timeout" or "application error" because Azure is failing to ping the application, check Deployment Center => Containers => main => Port and make sure it is set to 8000. If it isn't set to 8000, Azure will ping the wrong port and won't be able to reach Django.
+
+## Future considerations
+- Entra to Okta auth migration
+- Add teammates as key vault secrets officers
+- Automate Azure app service app restart after new code changes
+
+# Info about the cloud deployment
+## Primary Azure resources + descriptions
+### Azure App Service
+The App Service resource is where the Django application is hosted. It provides a web address for the application and a managed virtual machine that runs our Docker container. It also uses a GitHub Personal Access Token (PAT) to get permission from GitHub to pull our auto-built Docker container from the GitHub Container Registry. (If you are curious about how our Docker auto-build process works, it happens every time you merge a PR into `main`, and the code that runs it is located in `deploy.yml`.)
+
+### Azure Database for PostgreSQL
+This is the database that stores all the information collected via the clinic report form. It communicates with the App Service via a secure virtual network (VNet) that only the database, App Service, and Key Vault have access to.
+
+### Key Vault
+This is a secrets manager that stores sensitive deployment information like Django and Azure credentials. Key Vault uses the same VNet to connect to the App Service so that the application can pull secrets from Key Vault as if they were normal environment variables, while maintaining stronger security than a standard environment variable.
+
+### VNet + private endpoint
+The App Service, database, and Key Vault all use a shared VNet to communicate with each other so that traffic between these resources isn't exposed to the public internet. The database connects to the VNet using a private endpoint, whereas the App Service and Key Vault use built-in VNet integration.
+
+## How to update the cloud app
+- Merge code changes into the main branch of the repo--this will auto-build a Docker container and push it to the GitHub Container Registry
+- Go into the Azure portal, navigate to the App Service resource for your cloud deployment (may be called code-the-clinic or similar) and click "restart" under the Overview tab. This will force the app to restart and pull the latest version of the Docker container from GitHub. You may also need to navigate to the app's website and reload it a couple of times to get the webpage to "fetch" the new version of the code.

--- a/docs-site/docs/deployment-docs.md
+++ b/docs-site/docs/deployment-docs.md
@@ -6,7 +6,7 @@ hide:
 # How to deploy the application
 *Created by Holland Henderson-Boyer*
 
-Hi! Here's how to run our application locally, run tests, and deploy it in the cloud. In case you need to change Azure accounts later (for example, to move the application fully into the university tenant), you can use the Azure CLI and the bicep template files we've included to deploy without spending hours clicking through Azure's terrible GUI :)
+Hi! Here's how to run our application locally, run tests, and deploy it in the cloud. In case you need to change Azure region or tenant later, you can use the Azure CLI and the bicep template files we've included to redeploy without spending hours clicking through Azure's terrible GUI :)
 
 ## Required setup tools
 - Docker Desktop (needed to run Docker locally)
@@ -66,13 +66,15 @@ Hi! Here's how to run our application locally, run tests, and deploy it in the c
         - Now when you log in with your crimson email you should automatically be able to see the admin dashboard!
 
 ## How to deploy to Azure
-We currently have the application deployed in the university's Azure tenant! The name of our resource group is CHES-CS495-Capstone-Team-Code-the-Clinic-RG. There is a cost associated with our deployed resources (currently about $37 per month), which is billed to the AT department.
-If you need to re-deploy in the university's tenant for any reason (changing regions, fatal problem with current deployment, etc.), ask for the following roles from IT for bootstrapping:
+We currently have the application deployed in the university's Azure tenant! The name of our resource group is `CHES-CS495-Capstone-Team-Code-the-Clinic-RG`. There is a cost associated with our deployed resources (currently about $37 per month), which is billed to the AT department.
+
+### Permissions required from IT
 - Contributor
 - Key Vault Secrets Officer (to add new secrets)
 - Managed Identity Operator
 - Role Based Access Control Administrator
-After initial setup, you should only need Contributor (and possibly Key Vault Secrets Officer if you need to add/update secrets in Key Vault).
+
+If you need to re-deploy in the university's tenant for any reason (changing regions, fatal problem with current deployment, etc.), ask for all of the above permissions. For regular maintenance and development after initial setup, you should only need Contributor (and possibly Key Vault Secrets Officer if you need to add/update secrets in Key Vault).
 
 ### Pre-deployment todos
 - Fill in environment variables in main.bicepparam (before doing this, make your own local copy of main.bicepparam (call it main-local.bicepparam) that is gitignored so so environment variables aren't in a public github)

--- a/docs-site/mkdocs.yml
+++ b/docs-site/mkdocs.yml
@@ -12,6 +12,8 @@ nav:
   - Home: index.md
   - 'Meet the Team': team.md
   - 'Project Deliverables': deliverables.md
+  - 'Documentation for Developers': deployment-docs.md
+  - 'Cybersecurity Assessment': cyber-assessment.md
 
 markdown_extensions:
   - attr_list     # Allows you to use { width="100" }

--- a/docs-site/mkdocs.yml
+++ b/docs-site/mkdocs.yml
@@ -12,7 +12,7 @@ nav:
   - Home: index.md
   - 'Meet the Team': team.md
   - 'Project Deliverables': deliverables.md
-  - 'Documentation for Developers': deployment-docs.md
+  - 'Deployment Documentation': deployment-docs.md
   - 'Cybersecurity Assessment': cyber-assessment.md
 
 markdown_extensions:

--- a/main.bicep
+++ b/main.bicep
@@ -1,0 +1,815 @@
+// Resource naming parameters
+param sites_code_the_clinic_name string
+param serverfarms_ASP_capstone_976d_name string
+param vaults_code_the_clinic_vault_name string
+param virtualNetworks_code_the_clinic_vnet_name string
+param privateEndpoints_code_the_clinic_db_pe_name string
+param flexibleServers_code_the_clinic_db_name string
+param privateDnsZones_privatelink_postgres_database_azure_com_name string
+
+// Location parameters
+param location string
+param locationLower string
+
+// Networking parameters
+param networkAddressSpace string
+param subnetDefault string
+param subnetAppService string
+param subnetDeploymentScript string
+param vaultSubnetIpAddress string
+
+// Application parameters
+param containerImage string
+param containerPort string
+param siteContainerUserName string
+param minTlsVersion string = '1.2'
+param healthCheckPath string = '/health/'
+
+// Environment variables (not secrets--secrets are stored in Key Vault!)
+param allowedDomains string
+param allowedHosts string
+param csrfTrustedOrigins string
+
+// Database parameters
+param tenantId string = subscription().tenantId
+@description('The Object ID of the Entra user/group to be the DB Admin')
+param dbAdminObjectIds array = []
+@description('Set to false to skip deploying the DB identity bootstrap script and its managed identity/role assignment. Use this when you want to run the SQL setup manually from Cloud Shell instead of via a deployment script.')
+param runAutomatedDbIdentitySetup bool = true
+
+resource flexibleServers_code_the_clinic_db_name_resource 'Microsoft.DBforPostgreSQL/flexibleServers@2025-01-01-preview' = {
+  name: flexibleServers_code_the_clinic_db_name
+  location: location
+  sku: {
+    name: 'Standard_B1ms'
+    tier: 'Burstable'
+  }
+  properties: {
+    replica: {
+      role: 'Primary'
+    }
+    storage: {
+      iops: 120
+      tier: 'P4'
+      storageSizeGB: 32
+      autoGrow: 'Disabled'
+    }
+    network: {
+      publicNetworkAccess: 'Enabled'
+    }
+    dataEncryption: {
+      type: 'SystemManaged'
+    }
+    authConfig: {
+      activeDirectoryAuth: 'Enabled'
+      passwordAuth: 'Disabled'
+      tenantId: tenantId
+    }
+    version: '15'
+    backup: {
+      backupRetentionDays: 7
+      geoRedundantBackup: 'Disabled'
+    }
+    highAvailability: {
+      mode: 'Disabled'
+    }
+    maintenanceWindow: {
+      customWindow: 'Disabled'
+      dayOfWeek: 0
+      startHour: 0
+      startMinute: 0
+    }
+    replicationRole: 'Primary'
+  }
+}
+
+resource privateDnsZones_privatelink_postgres_database_azure_com_name_resource 'Microsoft.Network/privateDnsZones@2024-06-01' = {
+  name: privateDnsZones_privatelink_postgres_database_azure_com_name
+  location: 'global'
+  properties: {}
+}
+
+resource virtualNetworks_code_the_clinic_vnet_name_resource 'Microsoft.Network/virtualNetworks@2024-07-01' = {
+  name: virtualNetworks_code_the_clinic_vnet_name
+  location: locationLower
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        networkAddressSpace
+      ]
+    }
+    encryption: {
+      enabled: false
+      enforcement: 'AllowUnencrypted'
+    }
+    privateEndpointVNetPolicies: 'Disabled'
+    subnets: [
+      {
+        name: 'default'
+        properties: {
+          addressPrefixes: [
+            subnetDefault
+          ]
+          delegations: []
+          privateEndpointNetworkPolicies: 'Disabled'
+          privateLinkServiceNetworkPolicies: 'Enabled'
+        }
+      }
+      {
+        name: 'app-service-subnet'
+        properties: {
+          addressPrefixes: [
+            subnetAppService
+          ]
+          serviceEndpoints: [
+            {
+              service: 'Microsoft.KeyVault'
+              locations: [
+                '*'
+              ]
+            }
+            {
+              service: 'Microsoft.Sql'
+              locations: [
+                locationLower
+              ]
+            }
+          ]
+          delegations: [
+            {
+              name: 'Microsoft.Web/serverFarms'
+              properties: {
+                serviceName: 'Microsoft.Web/serverFarms'
+              }
+            }
+          ]
+          privateEndpointNetworkPolicies: 'Disabled'
+          privateLinkServiceNetworkPolicies: 'Enabled'
+        }
+      }
+      {
+        name: 'deployment-script-subnet'
+        properties: {
+          addressPrefixes: [
+            subnetDeploymentScript
+          ]
+          serviceEndpoints: []
+          delegations: [
+            {
+              name: 'Microsoft.ContainerInstance.containerGroups'
+              properties: {
+                serviceName: 'Microsoft.ContainerInstance/containerGroups'
+              }
+            }
+          ]
+          privateEndpointNetworkPolicies: 'Disabled'
+          privateLinkServiceNetworkPolicies: 'Enabled'
+        }
+      }
+    ]
+    virtualNetworkPeerings: []
+    enableDdosProtection: false
+  }
+}
+
+resource serverfarms_ASP_capstone_976d_name_resource 'Microsoft.Web/serverfarms@2024-11-01' = {
+  name: serverfarms_ASP_capstone_976d_name
+  location: location
+  sku: {
+    name: 'B1'
+    tier: 'Basic'
+    size: 'B1'
+    family: 'B'
+    capacity: 1
+  }
+  kind: 'linux'
+  properties: {
+    perSiteScaling: false
+    elasticScaleEnabled: false
+    maximumElasticWorkerCount: 1
+    isSpot: false
+    reserved: true
+    isXenon: false
+    hyperV: false
+    targetWorkerCount: 0
+    targetWorkerSizeId: 0
+    zoneRedundant: false
+    asyncScalingEnabled: false
+  }
+}
+
+// Create Entra admins (put teammates' object IDs in dbAdminObjectIds)
+resource postgresAdmin 'Microsoft.DBforPostgreSQL/flexibleServers/administrators@2025-01-01-preview' = [for (adminId, i) in dbAdminObjectIds: {
+  parent: flexibleServers_code_the_clinic_db_name_resource
+  name: adminId
+  properties: {
+    principalName: 'Admin-${i}' // Generic label for the portal
+    principalType: 'User'
+    tenantId: tenantId
+  }
+}]
+
+resource flexibleServers_code_the_clinic_db_name_Default 'Microsoft.DBforPostgreSQL/flexibleServers/advancedThreatProtectionSettings@2025-01-01-preview' = {
+  parent: flexibleServers_code_the_clinic_db_name_resource
+  name: 'Default'
+  properties: {
+    state: 'Disabled'
+  }
+}
+
+resource flexibleServers_code_the_clinic_db_name_flexibleServers_code_the_clinic_db_name 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2025-01-01-preview' = {
+  parent: flexibleServers_code_the_clinic_db_name_resource
+  name: flexibleServers_code_the_clinic_db_name
+  properties: {
+    charset: 'UTF8'
+    collation: 'en_US.utf8'
+  }
+}
+
+// Temporary bootstrap rule so Azure-hosted deployment script can reach PostgreSQL public endpoint.
+// Remove/lock down after deployment, then disable public network access again.
+resource flexibleServerAllowAzureServices 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2025-01-01-preview' = {
+  parent: flexibleServers_code_the_clinic_db_name_resource
+  name: 'AllowAzureServices'
+  properties: {
+    startIpAddress: '0.0.0.0'
+    endIpAddress: '0.0.0.0'
+  }
+}
+
+resource vaults_code_the_clinic_vault_name_resource 'Microsoft.KeyVault/vaults@2024-12-01-preview' = {
+  name: vaults_code_the_clinic_vault_name
+  location: locationLower
+  properties: {
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    tenantId: tenantId
+    networkAcls: {
+      bypass: 'AzureServices'
+      defaultAction: 'Deny'
+      ipRules: [
+        {
+          value: vaultSubnetIpAddress
+        }
+      ]
+      virtualNetworkRules: [
+        {
+          id: '${virtualNetworks_code_the_clinic_vnet_name_resource.id}/subnets/app-service-subnet'
+          ignoreMissingVnetServiceEndpoint: false
+        }
+      ]
+    }
+    accessPolicies: []
+    enabledForDeployment: false
+    enabledForDiskEncryption: false
+    enabledForTemplateDeployment: false
+    enableSoftDelete: true
+    softDeleteRetentionInDays: 90
+    enableRbacAuthorization: true
+    vaultUri: 'https://${vaults_code_the_clinic_vault_name}${environment().suffixes.keyvaultDns}'
+    provisioningState: 'Succeeded'
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+resource vaults_code_the_clinic_vault_name_azure_client_id 'Microsoft.KeyVault/vaults/secrets@2024-12-01-preview' = {
+  parent: vaults_code_the_clinic_vault_name_resource
+  name: 'azure-client-id'
+  properties: {
+    value: ''
+    attributes: {
+      enabled: true
+    }
+  }
+}
+
+resource vaults_code_the_clinic_vault_name_azure_secret 'Microsoft.KeyVault/vaults/secrets@2024-12-01-preview' = {
+  parent: vaults_code_the_clinic_vault_name_resource
+  name: 'azure-secret'
+  properties: {
+    value: ''
+    attributes: {
+      enabled: true
+    }
+  }
+}
+
+resource vaults_code_the_clinic_vault_name_azure_tenant_id 'Microsoft.KeyVault/vaults/secrets@2024-12-01-preview' = {
+  parent: vaults_code_the_clinic_vault_name_resource
+  name: 'azure-tenant-id'
+  properties: {
+    value: tenantId
+    attributes: {
+      enabled: true
+    }
+  }
+}
+
+resource vaults_code_the_clinic_vault_name_db_host 'Microsoft.KeyVault/vaults/secrets@2024-12-01-preview' = {
+  parent: vaults_code_the_clinic_vault_name_resource
+  name: 'db-host'
+  properties: {
+    value: '${flexibleServers_code_the_clinic_db_name_resource.name}.postgres.database.azure.com'
+    attributes: {
+      enabled: true
+    }
+  }
+}
+
+resource vaults_code_the_clinic_vault_name_django_secret_key 'Microsoft.KeyVault/vaults/secrets@2024-12-01-preview' = {
+  parent: vaults_code_the_clinic_vault_name_resource
+  name: 'django-secret-key'
+  properties: {
+    value: ''
+    attributes: {
+      enabled: true
+    }
+  }
+}
+
+resource vaults_code_the_clinic_vault_name_postgres_db 'Microsoft.KeyVault/vaults/secrets@2024-12-01-preview' = {
+  parent: vaults_code_the_clinic_vault_name_resource
+  name: 'postgres-db'
+  properties: {
+    value: flexibleServers_code_the_clinic_db_name_resource.name
+    attributes: {
+      enabled: true
+    }
+  }
+}
+
+resource vaults_code_the_clinic_vault_name_postgres_user 'Microsoft.KeyVault/vaults/secrets@2024-12-01-preview' = {
+  parent: vaults_code_the_clinic_vault_name_resource
+  name: 'postgres-user'
+  properties: {
+    value: sites_code_the_clinic_name_resource.name
+    attributes: {
+      enabled: true
+    }
+  }
+}
+
+resource vaults_code_the_clinic_vault_name_microsoft_login_client_id 'Microsoft.KeyVault/vaults/secrets@2024-12-01-preview' = {
+  parent: vaults_code_the_clinic_vault_name_resource
+  name: 'microsoft-login-client-id'
+  properties: {
+    value: ''
+    attributes: {
+      enabled: true
+    }
+  }
+}
+
+resource Microsoft_Network_privateDnsZones_SOA_privateDnsZones_privatelink_postgres_database_azure_com_name 'Microsoft.Network/privateDnsZones/SOA@2024-06-01' = {
+  parent: privateDnsZones_privatelink_postgres_database_azure_com_name_resource
+  name: '@'
+  properties: {
+    ttl: 3600
+    soaRecord: {
+      email: 'azureprivatedns-host.microsoft.com'
+      expireTime: 2419200
+      host: 'azureprivatedns.net'
+      minimumTtl: 10
+      refreshTime: 3600
+      retryTime: 300
+      serialNumber: 1
+    }
+  }
+}
+
+resource sites_code_the_clinic_name_ftp 'Microsoft.Web/sites/basicPublishingCredentialsPolicies@2024-11-01' = {
+  parent: sites_code_the_clinic_name_resource
+  name: 'ftp'
+  properties: {
+    allow: false
+  }
+}
+
+resource sites_code_the_clinic_name_scm 'Microsoft.Web/sites/basicPublishingCredentialsPolicies@2024-11-01' = {
+  parent: sites_code_the_clinic_name_resource
+  name: 'scm'
+  properties: {
+    allow: false
+  }
+}
+
+resource sites_code_the_clinic_name_web 'Microsoft.Web/sites/config@2024-11-01' = {
+  parent: sites_code_the_clinic_name_resource
+  name: 'web'
+  properties: {
+    numberOfWorkers: 1
+    defaultDocuments: [
+      'Default.htm'
+      'Default.html'
+      'Default.asp'
+      'index.htm'
+      'index.html'
+      'iisstart.htm'
+      'default.aspx'
+      'index.php'
+      'hostingstart.html'
+    ]
+    netFrameworkVersion: 'v4.0'
+    linuxFxVersion: 'sitecontainers'
+    requestTracingEnabled: false
+    remoteDebuggingEnabled: false
+    remoteDebuggingVersion: 'VS2022'
+    httpLoggingEnabled: true
+    acrUseManagedIdentityCreds: false
+    logsDirectorySizeLimit: 35
+    detailedErrorLoggingEnabled: false
+    publishingUsername: 'REDACTED'
+    scmType: 'None'
+    use32BitWorkerProcess: true
+    webSocketsEnabled: false
+    alwaysOn: false
+    managedPipelineMode: 'Integrated'
+    virtualApplications: [
+      {
+        virtualPath: '/'
+        physicalPath: 'site\\wwwroot'
+        preloadEnabled: false
+      }
+    ]
+    loadBalancing: 'LeastRequests'
+    experiments: {
+      rampUpRules: []
+    }
+    autoHealEnabled: false
+    vnetName: 'app-service-subnet'
+    vnetRouteAllEnabled: true
+    vnetPrivatePortsCount: 0
+    publicNetworkAccess: 'Enabled'
+    localMySqlEnabled: false
+    managedServiceIdentityId: 13915
+    ipSecurityRestrictions: [
+      {
+        ipAddress: 'Any'
+        action: 'Allow'
+        priority: 2147483647
+        name: 'Allow all'
+        description: 'Allow all access'
+      }
+    ]
+    scmIpSecurityRestrictions: [
+      {
+        ipAddress: 'Any'
+        action: 'Allow'
+        priority: 2147483647
+        name: 'Allow all'
+        description: 'Allow all access'
+      }
+    ]
+    scmIpSecurityRestrictionsUseMain: false
+    http20Enabled: false
+    minTlsVersion: minTlsVersion
+    scmMinTlsVersion: minTlsVersion
+    ftpsState: 'Disabled'
+    preWarmedInstanceCount: 0
+    elasticWebAppScaleLimit: 0
+    healthCheckPath: healthCheckPath
+    functionsRuntimeScaleMonitoringEnabled: false
+    minimumElasticInstanceCount: 1
+    azureStorageAccounts: {}
+    http20ProxyFlag: 0
+  }
+}
+
+resource sites_code_the_clinic_name_main 'Microsoft.Web/sites/sitecontainers@2024-11-01' = {
+  parent: sites_code_the_clinic_name_resource
+  name: 'main'
+  properties: {
+    image: containerImage
+    targetPort: containerPort
+    isMain: true
+    authType: 'UserCredentials'
+    userName: siteContainerUserName
+    volumeMounts: []
+    environmentVariables: []
+    inheritAppSettingsAndConnectionStrings: true
+  }
+}
+
+resource privateDnsZones_privatelink_postgres_database_azure_com_name_gbuncm7wbtfng 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = {
+  parent: privateDnsZones_privatelink_postgres_database_azure_com_name_resource
+  name: 'gbuncm7wbtfng'
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    resolutionPolicy: 'Default'
+    virtualNetwork: {
+      id: virtualNetworks_code_the_clinic_vnet_name_resource.id
+    }
+  }
+}
+
+resource privateEndpoints_code_the_clinic_db_pe_name_resource 'Microsoft.Network/privateEndpoints@2024-07-01' = {
+  name: privateEndpoints_code_the_clinic_db_pe_name
+  location: locationLower
+  properties: {
+    privateLinkServiceConnections: [
+      {
+        name: privateEndpoints_code_the_clinic_db_pe_name
+        properties: {
+          privateLinkServiceId: flexibleServers_code_the_clinic_db_name_resource.id
+          groupIds: [
+            'postgresqlServer'
+          ]
+          privateLinkServiceConnectionState: {
+            status: 'Approved'
+            description: 'Auto-Approved'
+          }
+        }
+      }
+    ]
+    manualPrivateLinkServiceConnections: []
+    customNetworkInterfaceName: '${privateEndpoints_code_the_clinic_db_pe_name}-nic'
+    subnet: {
+      id: '${virtualNetworks_code_the_clinic_vnet_name_resource.id}/subnets/default'
+    }
+    ipConfigurations: []
+    customDnsConfigs: []
+  }
+}
+
+resource privateEndpoints_code_the_clinic_db_pe_name_default 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2024-07-01' = {
+  parent: privateEndpoints_code_the_clinic_db_pe_name_resource
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'privatelink-postgres-database-azure-com'
+        properties: {
+          privateDnsZoneId: privateDnsZones_privatelink_postgres_database_azure_com_name_resource.id
+        }
+      }
+    ]
+  }
+}
+
+resource sites_code_the_clinic_name_resource 'Microsoft.Web/sites@2024-11-01' = {
+  name: sites_code_the_clinic_name
+  location: location
+  kind: 'app,linux'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    enabled: true
+    hostNameSslStates: [
+      {
+        name: '${sites_code_the_clinic_name}.azurewebsites.net'
+        sslState: 'Disabled'
+        hostType: 'Standard'
+      }
+      {
+        name: '${sites_code_the_clinic_name}.scm.azurewebsites.net'
+        sslState: 'Disabled'
+        hostType: 'Repository'
+      }
+    ]
+    serverFarmId: serverfarms_ASP_capstone_976d_name_resource.id
+    reserved: true
+    isXenon: false
+    hyperV: false
+    dnsConfiguration: {}
+    outboundVnetRouting: {
+      allTraffic: false
+      applicationTraffic: true
+      contentShareTraffic: false
+      imagePullTraffic: false
+      backupRestoreTraffic: false
+    }
+    siteConfig: {
+      numberOfWorkers: 1
+      linuxFxVersion: 'sitecontainers'
+      acrUseManagedIdentityCreds: false
+      alwaysOn: false
+      http20Enabled: false
+      functionAppScaleLimit: 0
+      minimumElasticInstanceCount: 1
+    }
+    scmSiteAlsoStopped: false
+    clientAffinityEnabled: false
+    clientAffinityProxyEnabled: false
+    clientCertEnabled: false
+    clientCertMode: 'Required'
+    hostNamesDisabled: false
+    ipMode: 'IPv4'
+    // customDomainVerificationId: 'REPLACE_WITH_YOUR_CUSTOM_DOMAIN_VERIFICATION_ID' // Set this when using custom domains
+    containerSize: 0
+    dailyMemoryTimeQuota: 0
+    httpsOnly: true
+    endToEndEncryptionEnabled: false
+    redundancyMode: 'None'
+    publicNetworkAccess: 'Enabled'
+    storageAccountRequired: false
+    virtualNetworkSubnetId: '${virtualNetworks_code_the_clinic_vnet_name_resource.id}/subnets/app-service-subnet'
+    keyVaultReferenceIdentity: 'SystemAssigned'
+    autoGeneratedDomainNameLabelScope: 'TenantReuse'
+    sshEnabled: true
+  }
+}
+
+// Set app environment variables
+resource siteConfigSettings 'Microsoft.Web/sites/config@2024-11-01' = {
+  name: 'appsettings'
+  parent: sites_code_the_clinic_name_resource
+  properties: {
+    // Values read from Key Vault
+    AZURE_SECRET: '@Microsoft.KeyVault(VaultName=${vaults_code_the_clinic_vault_name_resource.name};SecretName=azure-secret)'
+    AZURE_TENANT_ID: '@Microsoft.KeyVault(VaultName=${vaults_code_the_clinic_vault_name_resource.name};SecretName=azure-tenant-id)'
+    DJANGO_SECRET_KEY: '@Microsoft.KeyVault(VaultName=${vaults_code_the_clinic_vault_name_resource.name};SecretName=django-secret-key)'
+    MICROSOFT_LOGIN_CLIENT_ID: '@Microsoft.KeyVault(VaultName=${vaults_code_the_clinic_vault_name_resource.name};SecretName=microsoft-login-client-id)'
+    POSTGRES_DB: '@Microsoft.KeyVault(VaultName=${vaults_code_the_clinic_vault_name_resource.name};SecretName=postgres-db)'
+    POSTGRES_HOST: '@Microsoft.KeyVault(VaultName=${vaults_code_the_clinic_vault_name_resource.name};SecretName=db-host)'
+    POSTGRES_USER: '@Microsoft.KeyVault(VaultName=${vaults_code_the_clinic_vault_name_resource.name};SecretName=postgres-user)'
+
+    // Regular environment variables (no Key Vault needed)
+    DEBUG: 'False' // Always set DEBUG=False in production
+    ALLOWED_DOMAINS: allowedDomains
+    ALLOWED_HOSTS: allowedHosts
+    CSRF_TRUSTED_ORIGINS: csrfTrustedOrigins
+    PORT: '8000'
+    WEBSITE_HEALTHCHECK_MAXPINGFAILURES: '10'
+    WEBSITE_HTTPLOGGING_RETENTION_DAYS: '10'
+    WEBSITES_ENABLE_APP_SERVICE_STORAGE: 'false'
+    WEBSITES_PORT: '8000'
+  }
+}
+
+resource sites_code_the_clinic_name_app_service_subnet_connection 'Microsoft.Web/sites/virtualNetworkConnections@2024-11-01' = {
+  parent: sites_code_the_clinic_name_resource
+  name: 'app-service-subnet'
+  properties: {
+    vnetResourceId: '${virtualNetworks_code_the_clinic_vnet_name_resource.id}/subnets/app-service-subnet'
+    isSwift: true
+  }
+}
+
+resource kvRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(vaults_code_the_clinic_vault_name_resource.id, sites_code_the_clinic_name_resource.id, 'Key Vault Secrets User')
+  scope: vaults_code_the_clinic_vault_name_resource
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6') // ID for "Key Vault Secrets User"
+    principalId: sites_code_the_clinic_name_resource.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource deploymentScriptUserAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = if (runAutomatedDbIdentitySetup) {
+  name: '${sites_code_the_clinic_name}-dbscript-mi'
+  location: location
+}
+
+resource deploymentScriptServerContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (runAutomatedDbIdentitySetup) {
+  name: guid(flexibleServers_code_the_clinic_db_name_resource.id, deploymentScriptUserAssignedIdentity.id, 'Contributor')
+  scope: flexibleServers_code_the_clinic_db_name_resource
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c') // Contributor
+    principalId: deploymentScriptUserAssignedIdentity!.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource dbIdentitySetupScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = if (runAutomatedDbIdentitySetup) {
+  name: '${sites_code_the_clinic_name}-db-identity-setup'
+  location: location
+  kind: 'AzureCLI'
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${deploymentScriptUserAssignedIdentity.id}': {}
+    }
+  }
+  properties: {
+    azCliVersion: '2.63.0'
+    timeout: 'PT30M'
+    cleanupPreference: 'OnSuccess'
+    retentionInterval: 'P1D'
+    environmentVariables: [
+      {
+        name: 'DB_HOST'
+        value: '${flexibleServers_code_the_clinic_db_name_resource.name}.postgres.database.azure.com'
+      }
+      {
+        name: 'DB_NAME'
+        value: flexibleServers_code_the_clinic_db_name_resource.name
+      }
+      {
+        name: 'RESOURCE_GROUP_NAME'
+        value: resourceGroup().name
+      }
+      {
+        name: 'SUBSCRIPTION_ID'
+        value: subscription().subscriptionId
+      }
+      {
+        name: 'ARM_ENDPOINT'
+        value: environment().resourceManager
+      }
+      {
+        name: 'TENANT_ID'
+        value: tenantId
+      }
+      {
+        name: 'APP_SERVICE_NAME'
+        value: sites_code_the_clinic_name_resource.name
+      }
+      {
+        name: 'APP_OBJECT_ID'
+        value: sites_code_the_clinic_name_resource.identity.principalId
+      }
+      {
+        name: 'SCRIPT_MI_NAME'
+        value: deploymentScriptUserAssignedIdentity!.name
+      }
+      {
+        name: 'SCRIPT_MI_PRINCIPAL_ID'
+        value: deploymentScriptUserAssignedIdentity!.properties.principalId
+      }
+      {
+        name: 'SCRIPT_MI_CLIENT_ID'
+        value: deploymentScriptUserAssignedIdentity!.properties.clientId
+      }
+    ]
+    scriptContent: '''
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Ensuring PostgreSQL client (psql) is available..."
+if ! command -v psql >/dev/null 2>&1; then
+  if command -v apt-get >/dev/null 2>&1; then
+    apt-get update -y && apt-get install -y postgresql-client
+  elif command -v tdnf >/dev/null 2>&1; then
+    tdnf install -y postgresql
+  elif command -v yum >/dev/null 2>&1; then
+    yum install -y postgresql
+  elif command -v dnf >/dev/null 2>&1; then
+    dnf install -y postgresql
+  elif command -v apk >/dev/null 2>&1; then
+    apk add --no-cache postgresql-client
+  else
+    echo "No supported package manager found to install psql."
+    exit 1
+  fi
+fi
+
+if ! command -v psql >/dev/null 2>&1; then
+  echo "psql is still unavailable after installation attempt."
+  exit 1
+fi
+
+echo "Signing in with deployment script managed identity..."
+az login --identity --username "$SCRIPT_MI_CLIENT_ID" --allow-no-subscriptions 1>/dev/null
+
+echo "Setting deployment script managed identity as PostgreSQL Entra admin..."
+az rest --method PUT \
+  --url "${ARM_ENDPOINT}/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP_NAME}/providers/Microsoft.DBforPostgreSQL/flexibleServers/${DB_NAME}/administrators/${SCRIPT_MI_PRINCIPAL_ID}?api-version=2025-01-01-preview" \
+  --body "{\"properties\":{\"principalName\":\"${SCRIPT_MI_NAME}\",\"principalType\":\"ServicePrincipal\",\"tenantId\":\"${TENANT_ID}\"}}" 1>/dev/null
+
+echo "Waiting for PostgreSQL Entra admin propagation..."
+sleep 45
+
+echo "Getting PostgreSQL Entra token..."
+export PGPASSWORD=$(az account get-access-token --resource-type oss-rdbms --query accessToken -o tsv)
+
+echo "Applying DB identity mapping and grants for $APP_SERVICE_NAME..."
+psql "host=$DB_HOST port=5432 dbname=postgres user=$SCRIPT_MI_NAME sslmode=require" -v ON_ERROR_STOP=1 -v app_role="$APP_SERVICE_NAME" -v app_oid="$APP_OBJECT_ID" -v db_name="$DB_NAME" <<'SQL'
+SELECT format('CREATE ROLE %I WITH LOGIN', :'app_role')
+WHERE NOT EXISTS (
+  SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = :'app_role'
+) \gexec
+
+SELECT format('SECURITY LABEL FOR pgaadauth ON ROLE %I IS %L', :'app_role', format('aadauth,oid=%s,type=service', :'app_oid')) \gexec
+SELECT format('GRANT CONNECT ON DATABASE %I TO %I', :'db_name', :'app_role') \gexec
+SQL
+
+psql "host=$DB_HOST port=5432 dbname=$DB_NAME user=$SCRIPT_MI_NAME sslmode=require" -v ON_ERROR_STOP=1 -v app_role="$APP_SERVICE_NAME" <<'SQL'
+SELECT format('GRANT USAGE ON SCHEMA public TO %I', :'app_role') \gexec
+SELECT format('GRANT CREATE ON SCHEMA public TO %I', :'app_role') \gexec
+SELECT format('GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO %I', :'app_role') \gexec
+SELECT format('GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO %I', :'app_role') \gexec
+SELECT format('ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO %I', :'app_role') \gexec
+SELECT format('ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO %I', :'app_role') \gexec
+SQL
+
+echo "Identity setup complete."
+
+echo ""
+echo "Bootstrap complete! Post-deployment cleanup:"
+echo "  1. Verify app works and can access database"
+echo "  2. DISABLE PostgreSQL public network access (set to 'Disabled')"
+echo "  3. Remove deployment script MI from PostgreSQL Entra admins"
+echo "  4. Remove Contributor role from deployment script MI on PostgreSQL server"
+'''
+  }
+  dependsOn: [
+    deploymentScriptServerContributorRoleAssignment
+    flexibleServerAllowAzureServices
+    flexibleServers_code_the_clinic_db_name_flexibleServers_code_the_clinic_db_name
+    privateEndpoints_code_the_clinic_db_pe_name_default
+  ]
+}

--- a/main.bicepparam
+++ b/main.bicepparam
@@ -1,0 +1,44 @@
+// Make a copy of this and replace values as needed. If you are adding object IDs for Entra admins (dbAdminObjectIds),
+// do NOT push your local version to github! Add it to gitignore and only use it locally.
+
+using './main.bicep'
+
+// Toggle manual vs automatic DB setup in case of permission issues
+param runAutomatedDbIdentitySetup = true
+
+// Resource naming parameters
+param sites_code_the_clinic_name = 'code-the-clinic'
+param serverfarms_ASP_capstone_976d_name = 'ASP-capstone-976d'
+param vaults_code_the_clinic_vault_name = 'code-the-clinic-vault'
+param virtualNetworks_code_the_clinic_vnet_name = 'code-the-clinic-vnet'
+param privateEndpoints_code_the_clinic_db_pe_name = 'code-the-clinic-db-pe'
+param flexibleServers_code_the_clinic_db_name = 'code-the-clinic-db'
+param privateDnsZones_privatelink_postgres_database_azure_com_name = 'privatelink.postgres.database.azure.com'
+
+// Location parameters
+param location = 'East US'
+param locationLower = 'eastus'
+
+// Networking parameters
+param networkAddressSpace = '10.0.0.0/16'
+param subnetDefault = '10.0.0.0/24'
+param subnetAppService = '10.0.1.0/26'
+param subnetDeploymentScript = '10.0.2.0/27'
+param vaultSubnetIpAddress = '130.160.194.1/32'
+
+// Application parameters
+param containerImage = 'ghcr.io/code-the-clinic/code-the-clinic:main'
+param containerPort = '8000'
+// siteContainerUserName: Used for pulling container from GHCR into Azure.
+// Must be a GitHub username for someone who has permissions on the repository,
+// and they will need to enter a personal access token in Azure later (instructions
+// in deployment-docs.md) to give the App Service permission to pull from GHCR
+param siteContainerUserName = 'your-github-username'
+
+// Environment variables (replace items in <brackets> as needed)
+param allowedDomains = '<comma-separated string of university email domains>'
+param allowedHosts = 'localhost,127.0.0.1,0.0.0.0,<app-service-public-domain>,<app-service-ip-address>'
+param csrfTrustedOrigins = '<app-service-public-domain>'
+
+// Database parameters
+// param dbAdminObjectIds = []  // Uncomment and add Entra user/group object IDs to auto-add DB admins

--- a/main.bicepparam
+++ b/main.bicepparam
@@ -24,7 +24,10 @@ param networkAddressSpace = '10.0.0.0/16'
 param subnetDefault = '10.0.0.0/24'
 param subnetAppService = '10.0.1.0/26'
 param subnetDeploymentScript = '10.0.2.0/27'
-param vaultSubnetIpAddress = '130.160.194.1/32'
+// If you put an IP in vaultSubnetIpAddress, it will be allowed to access the Key Vault.
+// You can add your own IP for bootstrapping purposes, but make sure to remove it
+// in the Azure portal under your Key Vault resource once you are done adding/editing secrets.
+param vaultSubnetIpAddress = '<your-allowed-ip>'
 
 // Application parameters
 param containerImage = 'ghcr.io/code-the-clinic/code-the-clinic:main'

--- a/main.bicepparam
+++ b/main.bicepparam
@@ -34,6 +34,8 @@ param containerPort = '8000'
 // and they will need to enter a personal access token in Azure later (instructions
 // in deployment-docs.md) to give the App Service permission to pull from GHCR
 param siteContainerUserName = 'your-github-username'
+param minTlsVersion = '1.2'
+param healthCheckPath = '/health/'
 
 // Environment variables (replace items in <brackets> as needed)
 param allowedDomains = '<comma-separated string of university email domains>'


### PR DESCRIPTION
Changes:
- Add Azure deployment script (Bicep template), Bash script for setting up communication between the DB and App Service, and detailed documentation for deploying the application to the cloud
- Add final cybersecurity assessment and future issues to look at
- NOTE: All documentation is in the docs-site folder and is published on our project website. All deployment scripts are located in the root of the repo.

Testing:
- Manually deployed the template and verified that I could follow my own instructions (from the documentation) and get the app up and running in (a) my own personal Azure account and (b) the UA Azure tenant.