### PR TITLE
Follow security best practices by removing template variable from href

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -62,10 +62,26 @@ def _admin_login(request):
     query = urlencode({'next': next_url})
     return redirect(f'/accounts/microsoft/login/?{query}')
 
+
+def login_entry(request):
+    """Public login entry point used by templates.
+
+    Templates always link to the fixed named route 'login_entry' rather than
+    interpolating variables into href attributes, which avoids XSS patterns if
+    those variables ever become user-controlled.
+
+    The actual destination is controlled centrally via settings.LOGIN_URL
+    (e.g., /accounts/microsoft/login/ in Azure vs /accounts/login/ locally),
+    so auth behavior can change without touching templates.
+    """
+
+    return redirect(settings.LOGIN_URL)
+
 urlpatterns = [
     path('health/', lambda request: JsonResponse({"status": "ok"}), name='health'),
     path('health/db/', _db_health_check, name='health_db'),
     path('', include('core.urls')),
+    path('login/', login_entry, name='login_entry'),
     path(f'{ADMIN_URL}login/', _admin_login, name='admin_login'),
     path(ADMIN_URL, admin.site.urls, name='admin'),
     path('accounts/', include('allauth.urls'), name='accounts'),

--- a/backend/core/templates/core/base.html
+++ b/backend/core/templates/core/base.html
@@ -165,13 +165,7 @@
                         <a href="/dashboard/student/">Dashboard</a>
                     {% endif %}
                 {% else %}
-                    {% with login=login_url|default:'/accounts/login/' %}
-                        {% if login|slice:":11" != "javascript:" %}
-                            <a href="{{ login }}">Dashboard</a>
-                        {% else %}
-                            <a href="/accounts/login/">Dashboard</a>
-                        {% endif %}
-                    {% endwith %}
+                    <a href="{% url 'login_entry' %}">Dashboard</a>
                 {% endif %}
                 <a href="/clinic-reports/">Submit Report</a>
                 {% if user.is_authenticated %}
@@ -180,13 +174,7 @@
                     <button type="submit">Logout</button>
                 </form>
                 {% else %}
-                {% with login=login_url|default:'/accounts/login/' %}
-                    {% if login|slice:":11" != "javascript:" %}
-                        <a href="{{ login }}">Login</a>
-                    {% else %}
-                        <a href="/accounts/login/">Login</a>
-                    {% endif %}
-                {% endwith %}
+                    <a href="{% url 'login_entry' %}">Login</a>
                 {% endif %}
                 </div>
             </nav>

--- a/backend/core/templates/core/home.html
+++ b/backend/core/templates/core/home.html
@@ -34,13 +34,7 @@
     <div class="centered">
         <p class="muted">Sign in with myBama to submit reports and view dashboards.</p>
         <div class="button-row">
-        {% with login=login_url|default:'/accounts/login/' %}
-            {% if login|slice:":11" != "javascript:" %}
-                <a class="btn-primary" href="{{ login }}">Login with myBama</a>
-            {% else %}
-                <a class="btn-primary" href="/accounts/login/">Login with myBama</a>
-            {% endif %}
-        {% endwith %}
+            <a class="btn-primary" href="{% url 'login_entry' %}">Login with myBama</a>
         </div>
     </div>
 {% endif %}

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -394,9 +394,7 @@ def student_dashboard_view(request):
 
 def home_view(request):
     """Render the homepage."""
-    from django.conf import settings
-    context = {'login_url': settings.LOGIN_URL}
-    return render(request, 'core/home.html', context)
+    return render(request, 'core/home.html')
 
 
 def _apply_dashboard_filters(clinic_reports, filters):


### PR DESCRIPTION
Changes:
- Removed login url template variable from href in base and home templates and added a new login redirect endpoint URL that goes directly to Microsoft login if the app is running in Azure OR goes to the login provider chooser if the app is running locally.
- Note: This change is not in response to an active vulnerability, but prevents vulnerabilities in the future by making sure that the login URL in the HTML templates is set on the server side and can't become user-modifiable in the future.

Testing:
- Ran existing unit tests again to make sure the changes didn't break any functionality